### PR TITLE
Fix config change detection not working for multiple sortkey in materialized views

### DIFF
--- a/.changes/unreleased/Fixes-20240610-104114.yaml
+++ b/.changes/unreleased/Fixes-20240610-104114.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix config change detection not working for multiple sortkey in materialized views
+time: 2024-06-10T10:41:14.721411-03:00
+custom:
+    Author: lvitti
+    Issue: "838"

--- a/dbt/adapters/redshift/relation_configs/materialized_view.py
+++ b/dbt/adapters/redshift/relation_configs/materialized_view.py
@@ -167,6 +167,15 @@ class RedshiftMaterializedViewConfig(RedshiftRelationConfigBase, RelationConfigV
                     "query": agate.Table(
                         agate.Row({"definition": "<query>")}
                     ),
+                    "column_descriptor": agate.Table(
+                        agate.Row({
+                            "schema": "<schema_name>",
+                            "table": "<table_name>",
+                            "column": "<column_name>",
+                            "is_sort_key": any(true, false),
+                            "is_dist_key: any(true, false),
+                        })
+                    ),
                 }
 
                 Additional columns in either value is fine, as long as `sortkey` and `sortstyle` are available.
@@ -197,10 +206,10 @@ class RedshiftMaterializedViewConfig(RedshiftRelationConfigBase, RelationConfigV
                 {"dist": RedshiftDistConfig.parse_relation_results(materialized_view)}
             )
 
-        # TODO: this only shows the first column in the sort key
-        if materialized_view.get("sortkey1"):
+        column_descriptor = relation_results.get("column_descriptor")
+        if column_descriptor and len(column_descriptor.rows) > 0:
             config_dict.update(
-                {"sort": RedshiftSortConfig.parse_relation_results(materialized_view)}
+                {"sort": RedshiftSortConfig.parse_relation_results(column_descriptor.rows)}
             )
 
         return config_dict

--- a/dbt/adapters/redshift/relation_configs/materialized_view.py
+++ b/dbt/adapters/redshift/relation_configs/materialized_view.py
@@ -207,10 +207,12 @@ class RedshiftMaterializedViewConfig(RedshiftRelationConfigBase, RelationConfigV
             )
 
         column_descriptor = relation_results.get("column_descriptor")
-        if column_descriptor and len(column_descriptor.rows) > 0:
-            config_dict.update(
-                {"sort": RedshiftSortConfig.parse_relation_results(column_descriptor.rows)}
-            )
+        if column_descriptor:
+            sort_columns = [row for row in column_descriptor.rows if row.get("is_sort_key")]
+            if sort_columns:
+                config_dict.update(
+                    {"sort": RedshiftSortConfig.parse_relation_results(sort_columns)}
+                )
 
         return config_dict
 

--- a/tests/unit/test_materialized_view.py
+++ b/tests/unit/test_materialized_view.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock
 
+import agate
 import pytest
 
 from dbt.adapters.redshift.relation_configs import RedshiftMaterializedViewConfig
@@ -53,3 +54,58 @@ def test_redshift_materialized_view_config_throws_expected_exception_with_invali
     )
     with pytest.raises(ValueError):
         config.parse_relation_config(model_node)
+
+
+def test_redshift_materialized_view_parse_relation_results_handles_multiples_sort_key():
+    materialized_view = agate.Table.from_object(
+        [],
+        [
+            "database",
+            "schema",
+            "table",
+            "diststyle",
+            "sortkey1",
+            "autorefresh",
+        ],
+    )
+
+    column_descriptor = agate.Table.from_object(
+        [
+            {
+                "schema": "my_schema",
+                "table": "my_table",
+                "column": "my_column",
+                "is_dist_key": True,
+                "is_sort_key": True,
+            },
+            {
+                "schema": "my_schema",
+                "table": "my_table",
+                "column": "my_column2",
+                "is_dist_key": True,
+                "is_sort_key": True,
+            },
+        ],
+    )
+
+    query = agate.Table.from_object(
+        [
+            {
+                "definition": "create materialized view my_view as (select 1 as my_column, 'value' as my_column2)"
+            }
+        ]
+    )
+
+    relation_results = {
+        "materialized_view": materialized_view,
+        "column_descriptor": column_descriptor,
+        "query": query,
+    }
+
+    config_dict = RedshiftMaterializedViewConfig.parse_relation_results(
+        relation_results
+    )
+
+    assert isinstance(config_dict["sort"], dict)
+    assert config_dict["sort"]["sortkey"][0] == "my_column"
+    assert config_dict["sort"]["sortkey"][1] == "my_column2"

--- a/tests/unit/test_relation.py
+++ b/tests/unit/test_relation.py
@@ -28,7 +28,7 @@ def test_renameable_relation():
 
 
 @pytest.fixture
-def materialized_view_multiple_sort_key_from_db():
+def materialized_view_without_sort_key_from_db():
     materialized_view = agate.Table.from_object(
         [
             {
@@ -39,24 +39,7 @@ def materialized_view_multiple_sort_key_from_db():
         ],
     )
 
-    column_descriptor = agate.Table.from_object(
-        [
-            {
-                "schema": "my_schema",
-                "table": "my_table",
-                "column": "my_column",
-                "is_dist_key": True,
-                "is_sort_key": True,
-            },
-            {
-                "schema": "my_schema",
-                "table": "my_table",
-                "column": "my_column2",
-                "is_dist_key": True,
-                "is_sort_key": True,
-            },
-        ],
-    )
+    column_descriptor = agate.Table.from_object([])
 
     query = agate.Table.from_object(
         [
@@ -75,21 +58,61 @@ def materialized_view_multiple_sort_key_from_db():
 
 
 @pytest.fixture
-def materialized_view_multiple_sort_key_config():
+def materialized_view_without_sort_key_config():
     relation_config = Mock(spec=RelationConfig)
 
     relation_config.database = "my_db"
     relation_config.identifier = "my_table"
     relation_config.schema = "my_schema"
     relation_config.config = Mock()
-    relation_config.config.extra = {
-        "sort_type": RedshiftSortStyle.compound,
-        "sort": ["my_column", "my_column2"],
-    }
+    relation_config.config.extra = {}
     relation_config.config.sort = ""
     relation_config.compiled_code = "create materialized view my_view as (select 1 as my_column, 'value' as my_column2)"
     return relation_config
 
+
+@pytest.fixture
+def materialized_view_multiple_sort_key_from_db(materialized_view_without_sort_key_from_db):
+    materialized_view_without_sort_key_from_db["column_descriptor"] = agate.Table.from_object(
+        [
+            {
+                "schema": "my_schema",
+                "table": "my_table",
+                "column": "my_column",
+                "is_dist_key": True,
+                "is_sort_key": True,
+            },
+            {
+                "schema": "my_schema",
+                "table": "my_table",
+                "column": "my_column2",
+                "is_dist_key": True,
+                "is_sort_key": True,
+            },
+        ],
+    )
+    return materialized_view_without_sort_key_from_db
+
+
+@pytest.fixture
+def materialized_view_multiple_sort_key_config(materialized_view_without_sort_key_config):
+    materialized_view_without_sort_key_config.config.extra = {
+        "sort_type": RedshiftSortStyle.compound,
+        "sort": ["my_column", "my_column2"],
+    }
+
+    return materialized_view_without_sort_key_config
+
+def test_materialized_view_config_changeset_without_sort_key_empty_changes(
+    materialized_view_without_sort_key_from_db,
+    materialized_view_without_sort_key_config,
+):
+    change_set = RedshiftRelation.materialized_view_config_changeset(
+        materialized_view_without_sort_key_from_db,
+        materialized_view_without_sort_key_config,
+    )
+
+    assert change_set is None
 
 def test_materialized_view_config_changeset_multiple_sort_key_without_changes(
     materialized_view_multiple_sort_key_from_db,

--- a/tests/unit/test_relation.py
+++ b/tests/unit/test_relation.py
@@ -1,5 +1,15 @@
+from unittest.mock import Mock
+
+import agate
+import pytest
+
 from dbt.adapters.redshift.relation import RedshiftRelation
-from dbt.adapters.contracts.relation import RelationType
+from dbt.adapters.contracts.relation import (
+    RelationType,
+    RelationConfig,
+)
+
+from dbt.adapters.redshift.relation_configs.sort import RedshiftSortStyle
 
 
 def test_renameable_relation():
@@ -15,3 +25,95 @@ def test_renameable_relation():
             RelationType.Table,
         }
     )
+
+
+@pytest.fixture
+def materialized_view_multiple_sort_key_from_db():
+    materialized_view = agate.Table.from_object(
+        [
+            {
+                "database": "my_db",
+                "schema": "my_schema",
+                "table": "my_table",
+            }
+        ],
+    )
+
+    column_descriptor = agate.Table.from_object(
+        [
+            {
+                "schema": "my_schema",
+                "table": "my_table",
+                "column": "my_column",
+                "is_dist_key": True,
+                "is_sort_key": True,
+            },
+            {
+                "schema": "my_schema",
+                "table": "my_table",
+                "column": "my_column2",
+                "is_dist_key": True,
+                "is_sort_key": True,
+            },
+        ],
+    )
+
+    query = agate.Table.from_object(
+        [
+            {
+                "definition": "create materialized view my_view as (select 1 as my_column, 'value' as my_column2)"
+            }
+        ]
+    )
+
+    relation_results = {
+        "materialized_view": materialized_view,
+        "column_descriptor": column_descriptor,
+        "query": query,
+    }
+    return relation_results
+
+
+@pytest.fixture
+def materialized_view_multiple_sort_key_config():
+    relation_config = Mock(spec=RelationConfig)
+
+    relation_config.database = "my_db"
+    relation_config.identifier = "my_table"
+    relation_config.schema = "my_schema"
+    relation_config.config = Mock()
+    relation_config.config.extra = {
+        "sort_type": RedshiftSortStyle.compound,
+        "sort": ["my_column", "my_column2"],
+    }
+    relation_config.config.sort = ""
+    relation_config.compiled_code = "create materialized view my_view as (select 1 as my_column, 'value' as my_column2)"
+    return relation_config
+
+
+def test_materialized_view_config_changeset_multiple_sort_key_without_changes(
+    materialized_view_multiple_sort_key_from_db,
+    materialized_view_multiple_sort_key_config,
+):
+
+    change_set = RedshiftRelation.materialized_view_config_changeset(
+        materialized_view_multiple_sort_key_from_db,
+        materialized_view_multiple_sort_key_config,
+    )
+
+    assert change_set is None
+
+
+def test_materialized_view_config_changeset_multiple_sort_key_with_changes(
+    materialized_view_multiple_sort_key_from_db,
+    materialized_view_multiple_sort_key_config,
+):
+    materialized_view_multiple_sort_key_config.config.extra["sort"].append("my_column3")
+
+    change_set = RedshiftRelation.materialized_view_config_changeset(
+        materialized_view_multiple_sort_key_from_db,
+        materialized_view_multiple_sort_key_config,
+    )
+
+    assert change_set is not None
+    assert change_set.sort.context.sortkey == frozenset({"my_column", "my_column2", "my_column3"})


### PR DESCRIPTION
resolves #838

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

Having multiple sort keys and without changes between the model and the Materialized View, the change check between model and view ends up returning as a result that it has changes. This is because svv_table_info.sortkey1 is being used instead of use the list of sort key that the Materialized View have

### Solution

We can get the list of SortKeys using the `mv_tbl` related table

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX


### Steps To Reproduce:
1. Make sure to delete the MV first.
`drop materialized view if exists dev.public.mv_double_sort`

2. Add an mv to the project with more than 1 sort key:
```
-- models/mv_double_sort.sql
{{
    config(
        materialized = 'materialized_view',
        dist = 'b',
        sort = ['b', 'a'],
        on_configuration_change = 'fail'
    )
}}

select a, b, c from foo

```

3. `$ dbt --debug build -s my_double_sort` Should create the materialized view 
4. Run again `$ dbt --debug build -s my_double_sort` and should refresh the materialized view instead of drop and recreate the view