### PR TITLE
fix drop materialized view, missing cascade

### DIFF
--- a/dbt/include/redshift/macros/relations/materialized_view/drop.sql
+++ b/dbt/include/redshift/macros/relations/materialized_view/drop.sql
@@ -1,3 +1,3 @@
 {% macro redshift__drop_materialized_view(relation) -%}
-    drop materialized view if exists {{ relation }}
+    drop materialized view if exists {{ relation }} cascade
 {%- endmacro %}


### PR DESCRIPTION
resolves #642

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

When you refresh the materialized view but there are other views that depend on it, an error occurs.

### Solution

Add the cascade to the drop like already do for Table and view

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
